### PR TITLE
Add suport for decimal encoded images

### DIFF
--- a/lib/image.coffee
+++ b/lib/image.coffee
@@ -22,10 +22,10 @@ class PDFImage
         data = fs.readFileSync src
         return unless data
     
-    if data[0] is 0xff and data[1] is 0xd8
+    if data[0] is 0xff or 255 and data[1] is 0xd8 or 216
       return new JPEG(data, label)
       
-    else if data[0] is 0x89 and data.toString('ascii', 1, 4) is 'PNG'
+    else if data[0] is 0x89 or 137 and data.toString('ascii', 1, 4) is 'PNG'
       return new PNG(data, label)
       
     else


### PR DESCRIPTION
## Problem:
Many libraries (for example [bwip-js](https://github.com/metafloor/bwip-js)) encoding their images with decimal numbers and returning it to the buffer. So first byte of generated image looks like a decimal number, for example data[0] for PNG image, generated by bwip-js is 137 (0x89 in hex) and for JPEG - data[0] is 255 (0xff in hex). Your code checking image only if first byte is hexadecimal number, but it can be decimal too.
Because of that, valid images can't pass verification in the if...else statement and code throws an error 'Unknown image format.'.
## Solving:
So my changes add the opportunity to verificate if image is encoded with a decimal number. I have tested my changes in real projects, and your library works perfect with decimal encoded images and inserts the picture into the pdf document exactly as hexadecimal encoded image. Thank you.